### PR TITLE
Adds doctor variables to DLHS4 build #8

### DIFF
--- a/b/prep_dlhs4_district.do
+++ b/b/prep_dlhs4_district.do
@@ -25,13 +25,17 @@ egen dh_staff = rowtotal(qd2*_r)
 gen dh_icu_beds = qd68_total
 
 /* collapse */
-collapse (sum) dh_beds dh_count dh_staff dh_icu_beds, by(pc11_state_id pc11_district_id)
+collapse (sum) dh_beds dh_count dh_staff dh_icu_beds qd213_r qd214_c, by(pc11_state_id pc11_district_id)
 
 /* clean up */
 label var dh_beds "Total beds in district hospitals"
 label var dh_count "Total district hospitals"
 label var dh_staff "Total staff district hospitals"
 label var dh_icu_beds "Total beds in intensive medicare units"
+ren qd213_r dh_doc_reg
+label var dh_doc_reg "General Duty Doctor (regular)"
+ren qd214_c dh_doc_contract
+label var dh_doc_contract "General Duty Doctor (contractual)"
 
 /* save */
 save $tmp/dlhs4_dh_dist_beds, replace
@@ -60,13 +64,17 @@ egen chc_staff = rowtotal(qc2*a)
 gen chc_beds_ven = qc571 if qc72<3  &  qc73<3 &  qc44<3  &  qc78<3 & qc554k<3
 
 /* collapse */
-collapse (sum) chc_beds chc_count chc_staff chc_beds_ven, by(pc11_state_id pc11_district_id)
+collapse (sum) chc_beds chc_count chc_staff chc_beds_ven qc22a qc22b, by(pc11_state_id pc11_district_id)
 
 /* clean up */
 label var chc_beds "Total beds in community health centers"
 label var chc_count "Total community health centers"
 label var chc_staff "Total staff in community health centers"
 label var chc_beds_ven "Total beds in CHC with ventilator, oxygen, and cardiac monitor"
+ren qc22a chc_doc_reg
+label var chc_doc_reg "number of regular physician in position at CHC"
+ren qc22b chc_doc_contract
+label var chc_doc_contract "number of contractual physician in position at CHC"
 
 /* save */
 save $tmp/dlhs4_chc_dist_beds, replace
@@ -102,7 +110,7 @@ gen phc_beds_oxy = qp429b if qp428kk<3
 drop if mi(phc_pop) | phc_pop == 0 | mi(phc_beds) | phc_staff == 0
 
 /* collapse */
-collapse (sum) phc_beds phc_count phc_staff phc_pop phc_beds_oxy, by(pc11_state_id pc11_district_id)
+collapse (sum) phc_beds phc_count phc_staff phc_pop phc_beds_oxy qp21a qp21b, by(pc11_state_id pc11_district_id)
 
 /* clean up */
 label var phc_beds "Total beds in primary health centers"
@@ -110,6 +118,10 @@ label var phc_count "Total primary health centers"
 label var phc_staff "Total staff in primary health centers"
 label var phc_pop "Population covered by sampled primary health centers"
 label var phc_beds_oxy "Total beds in PHC with oxygen cylinders"
+ren qp21a phc_doc_reg
+label var phc_doc_reg "Regular MO in position at PHC"
+ren qp21b phc_doc_contract
+label var phc_doc_contract "contactual MO in position at PHC"
 
 /* save */
 save $tmp/dlhs4_phc_dist_beds, replace
@@ -130,7 +142,7 @@ drop _m_pca
 
 /* replace missing with 0 */
 foreach i in dh chc phc {
-  foreach j in beds count staff {
+  foreach j in beds count staff doc_reg doc_contract {
     replace `i'_`j' = 0 if mi(`i'_`j')
   }
 }
@@ -144,6 +156,9 @@ label var phc_mult "Sampling weight on PHCs"
 gen total_beds = dh_beds + chc_beds + (phc_beds * phc_mult)
 gen total_staff = dh_staff + chc_staff + (phc_staff * phc_mult)
 gen total_facilities = dh_count + chc_count + (phc_count * phc_mult)
+gen total_doc_reg = dh_doc_reg + chc_doc_reg + (phc_doc_reg * phc_mult)
+gen total_doc_contract = dh_doc_contract + chc_doc_contract + (phc_doc_contract * phc_mult)
+gen total_doc = total_doc_reg + total_doc_contract
 
 /* label remaining variables */
 label var total_beds "Total beds in all public facilities (DH + CHC + PHC)"
@@ -151,6 +166,9 @@ label var total_staff "Total staff in all public facilities (DH + CHC + PHC)"
 label var total_facilities "Total number of public facilities (DH + CHC + PHC)"
 label var pc11_state_id "2011 Population Census State ID"
 label var pc11_district_id "2011 Population Census District ID"
+label var total_doc_reg "Total regular general duty doctors"
+label var total_doc_contract "Total contract general duty doctors"
+label var total_doc "Total general duty doctors"
 
 /* clean up */
 ren * dlhs4_*


### PR DESCRIPTION
This adds two new variables to the DLHS build: one for contractual
general duty doctors and a second for regular general duty doctors. It
also includes a combined total doctors variable. These new variables
are more consistent with the doctor defintion in the PC build than the
original "total staff" variable in the DLHS build.